### PR TITLE
Update some examples to latest hotchocolate

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "5.0.100"
+    "version": "5.0",
+    "rollForward": "major",
+    "allowPrerelease": false
   }
 }

--- a/misc/CodeFirst/CodeFirst.csproj
+++ b/misc/CodeFirst/CodeFirst.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);1591</NoWarn>
+    <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="11.0.0" />
-    <PackageReference Include="HotChocolate.Data" Version="11.0.0" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="HotChocolate.Data" Version="11.3.0" />
   </ItemGroup>
 
 </Project>

--- a/misc/CodeFirst/Types/DroidType.cs
+++ b/misc/CodeFirst/Types/DroidType.cs
@@ -9,8 +9,6 @@ namespace StarWars.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Droid> descriptor)
         {
-            descriptor.Interface<CharacterType>();
-
             descriptor.Field(t => t.Id)
                 .Type<NonNullType<IdType>>();
 

--- a/misc/CodeFirst/Types/HumanType.cs
+++ b/misc/CodeFirst/Types/HumanType.cs
@@ -10,8 +10,6 @@ namespace StarWars.Types
     {
         protected override void Configure(IObjectTypeDescriptor<Human> descriptor)
         {
-            descriptor.Interface<CharacterType>();
-
             descriptor.Field(t => t.Id)
                 .Type<NonNullType<IdType>>();
 

--- a/misc/Stitching/centralized/accounts/Accounts.csproj
+++ b/misc/Stitching/centralized/accounts/Accounts.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="11.0.0-rc.2" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="11.3.0" />
   </ItemGroup>
   
 </Project>

--- a/misc/Stitching/centralized/gateway/Gateway.csproj
+++ b/misc/Stitching/centralized/gateway/Gateway.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="11.0.0-rc.2" />
-    <PackageReference Include="HotChocolate.Stitching" Version="11.0.0-rc.2" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="HotChocolate.Stitching" Version="11.3.0" />
   </ItemGroup>
 
 </Project>

--- a/misc/Stitching/centralized/gateway/Stitching.graphql
+++ b/misc/Stitching/centralized/gateway/Stitching.graphql
@@ -1,9 +1,11 @@
 extend type Query {
   me: User! @delegate(schema: "accounts", path: "user(id: 1)")
+  topProducts(first: Int = 5): [Product] @delegate(schema: "products")
 }
 
 extend type Review {
   author: User @delegate(schema: "accounts", path: "user(id: $fields:authorId)")
+  product: Product @delegate(schema: "products", path: "product(upc: $fields:upc)")
 }
 
 extend type Product {
@@ -15,20 +17,10 @@ extend type Product {
     @delegate(
       schema: "inventory"
       path: "shippingEstimate(price: $fields:price weight: $fields:weight)")
+  reviews: [Review] @delegate(schema: "reviews" path:"reviewsByProduct(upc: $fields:upc)")
 }
 
-extend type Query {
-  topProducts(first: Int = 5): [Product] @delegate(schema: "products")
-}
-
-extend type Review {
-  product: Product @delegate(schema: "products", path: "product(upc: $fields:upc)")
-}
 
 extend type User {
   reviews: [Review] @delegate(schema: "reviews" path:"reviewsByAuthor(authorId: $fields:id)")
-}
-
-extend type Product {
-  reviews: [Review] @delegate(schema: "reviews" path:"reviewsByProduct(upc: $fields:upc)")
 }

--- a/misc/Stitching/centralized/global.json
+++ b/misc/Stitching/centralized/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "5.0.100-rc.2.20479.15"
+    "version": "5.0",
+    "rollForward": "major",
+    "allowPrerelease": false
   }
 }

--- a/misc/Stitching/centralized/inventory/Inventory.csproj
+++ b/misc/Stitching/centralized/inventory/Inventory.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="11.0.0-rc.2" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="11.3.0" />
   </ItemGroup>
 </Project>

--- a/misc/Stitching/centralized/products/Products.csproj
+++ b/misc/Stitching/centralized/products/Products.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="11.0.0-rc.2" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="11.3.0" />
   </ItemGroup>
 </Project>

--- a/misc/Stitching/centralized/reviews/Reviews.csproj
+++ b/misc/Stitching/centralized/reviews/Reviews.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="11.0.0-rc.2" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="11.3.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Just a small PR updating the `CodeFirst` and `Stitching/centralized` examples to the latest version of Hotchocolate.

* Also made the sdk versions for these projects a little less specific 

Not sure if this is useful without updating all of the other examples, but looked like the different examples were on different versions already (e.g. PureCodeFirst is .net3.1 and using 10.3 version of hotchocolate) 