### PR TITLE
Fix null value for id field on inner nodes in MongoDB HotChocolate example

### DIFF
--- a/misc/MongoDB/12.1/Person/Address.cs
+++ b/misc/MongoDB/12.1/Person/Address.cs
@@ -2,6 +2,7 @@ namespace Demo;
 
 public class Address
 {
+    public Guid Id { get; init; }
     public string Street { get; init; }
 
     public string City { get; init; }


### PR DESCRIPTION
Related to #61

Add an `Id` field to the `Address` class in `misc/MongoDB/12.1/Person/Address.cs`.

* Add a new `Id` field of type `Guid` to the `Address` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ChilliCream/hotchocolate-examples/issues/61?shareId=33a0333f-7c29-4166-a4a3-75059430ba5e).